### PR TITLE
Change order of path buildup.

### DIFF
--- a/FixPath.py
+++ b/FixPath.py
@@ -22,7 +22,7 @@ def fixPath():
 	environ['PATH'] = getSysPath()
 
 	for pathItem in fixPathSettings.get("additional_path_items", []):
-		environ['PATH'] += ':' + pathItem
+		environ['PATH'] = pathItem + ':' + environ['PATH']
 
 
 def plugin_loaded():


### PR DESCRIPTION
This way the user specified paths take precedence over the system default paths, which is very useful for example when having multiple ruby versions installed.

Couldn't think of a case where this is unwanted, but I guess you might.
