### PR TITLE
Improve support for other shells like Fish

### DIFF
--- a/FixPath.py
+++ b/FixPath.py
@@ -8,14 +8,14 @@ originalEnv = {}
 
 
 def getSysPath():
-	command = "/usr/bin/login -fpql $USER $SHELL -l -c 'echo -n $PATH'"
+	command = "/usr/bin/login -fpql $USER $SHELL -l -c \"env | grep '^PATH='\""
 
 	# Execute command with original environ. Otherwise, our changes to the PATH propogate down to
 	# the shell we spawn, which re-adds the system path & returns it, leading to duplicate values.
 	sysPath = Popen(command, stdout=PIPE, shell=True, env=originalEnv).stdout.read()
 
 	# Decode the byte array into a string, remove trailing whitespace, remove trailing ':'
-	return sysPath.decode("utf-8").rstrip().rstrip(':')
+	return sysPath.decode("utf-8").rstrip().rstrip(':').lstrip('PATH=')
 
 
 def fixPath():


### PR DESCRIPTION
Fish Shell's $PATH variable contains directories separated by spaces
instead of using colons. Example:

bash -> /usr/local/bin:/usr/local/sbin:/usr/bin
fish -> /usr/local/bin /usr/local/sbin /usr/bin

To get around this inconsistency and others in different shells,
the $PATH is now extracted from the output of the 'env' utility,
which has the same consistent format independently of the
user's configured login shell.

fixes #6
