### PR TITLE
Support fish-shell

### DIFF
--- a/FixPath.py
+++ b/FixPath.py
@@ -17,7 +17,7 @@ if isMac():
 	originalEnv = {}
 
 	def getSysPath():
-		command = "TERM=ansi CLICOLOR=\"\" SUBLIME=1 /usr/bin/login -fqpl $USER $SHELL -l -c 'TERM=ansi CLICOLOR=\"\" SUBLIME=1 printf \"%s\" \"$PATH\"'"
+		command = "TERM=ansi CLICOLOR=\"\" SUBLIME=1 /usr/bin/login -fqpl $USER $SHELL -l -c 'env TERM=ansi CLICOLOR=\"\" SUBLIME=1 printf \"%s:\" $PATH'"
 
 		# Execute command with original environ. Otherwise, our changes to the PATH propogate down to
 		# the shell we spawn, which re-adds the system path & returns it, leading to duplicate values.


### PR DESCRIPTION
Hi,

this plugin is fantastic! So much better than patching plist files or manually setting the path to every specific command. I'm going to recommend it with my every plugin.

But, since [fish-shell](http://fishshell.com) is not sh-compatible, it wouldn't work with this plugin, because:
- fish-shell doesn't support setting environment variables before a command and
- fish-shell's $PATH is space-separated rather than semicolon-separated.

Both of these issues could be fixed with a couple of changes to the getSysPath command, while preserving its compatibility with Bourne shells (I checked bash and zsh).
