### PR TITLE
Fix command for fetching PATH

### DIFF
--- a/FixPath.py
+++ b/FixPath.py
@@ -17,7 +17,7 @@ if isMac():
 	originalEnv = {}
 
 	def getSysPath():
-		command = "TERM=ansi CLICOLOR=\"\" SUBLIME=1 /usr/bin/login -fqpl $USER $SHELL -l -c 'TERM=ansi CLICOLOR=\"\" SUBLIME=1 printf \"%s\" \"$PATH\"'"
+		command = "TERM=ansi CLICOLOR=\"\" SUBLIME=1 /usr/bin/login -fqpl " + environ['USER'] + " " + environ['SHELL'] + " -l -c 'TERM=ansi CLICOLOR=\"\" SUBLIME=1 printf \"%s\" \"$PATH\"'"
 
 		# Execute command with original environ. Otherwise, our changes to the PATH propogate down to
 		# the shell we spawn, which re-adds the system path & returns it, leading to duplicate values.


### PR DESCRIPTION
For some reason, `$USER` was not properly set when running the `login` command.

I'm OSX 10.10, but I can't say if that is the underlying cause. I would however throw a guess that this fixes #10.
