### PR TITLE
Add additional env_vars fetching support and interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Fix Mac Path
 ==============
 
-On OS X, Sublime Text has its PATH set by launchctl, not by your shell<sup>1</sup>. Commands like `make` run by Sublime Text are then unable to find non-system binaries, including those installed by homebrew and MacPorts.
+On OS X, Sublime Text has its PATH set by launchctl, not by your shell<sup>1</sup>. Commands like `make` run by Sublime Text are then unable to find non-system binaries, including those installed with Homebrew or MacPorts.
 
 Fix Mac Path is a simple plugin for Sublime Text 2 and 3 which sets Sublime Text's PATH to that reported by your shell. Now, if you add homebrew's `/usr/local/bin` directory to your PATH in .bash_profile (or whatever other way you set your shell's PATH,) Sublime Text will inherit that PATH.
 
@@ -25,13 +25,37 @@ for Sublime Text 2, or
 for Sublime Text 3.
 
 
-Options
------------
+##Options
 
-You can optionally set the following option to your user preferences:
+You can optionally set the following options to your User Preferences:
 
-* `"additional_path_items": []`
+        "fix_mac_path":
+        {
+            "additional_path_items": [
+                
+            ],
+            "env_vars":
+            [
+                "LIBRARY_PATH",
+                "C_INCLUDE_PATH",
+                "CPLUS_INCLUDE_PATH"
+            ],
+            "interactive": false
+        },
 
-  An array of strings of locations you wish to add to Sublime Text's PATH, in addition to those pulled from your shell.
+### additional_path_items
+An array of strings of locations you wish to add to Sublime Text's PATH, in addition to those pulled from your shell.
 
-  For example, to add `~/Desktop` and `~/bin` to the shell's PATH in Sublime Text, you would use `"additional_path_items": ["~/Desktop", "~/bin"]`.
+For example, to add `~/Desktop` and `~/bin` to the shell's PATH in Sublime Text, you would use `"additional_path_items": ["~/Desktop", "~/bin"]`.
+
+
+### env_vars
+
+List of environment variables to fetch from shell to Sublime Text.
+
+
+### interactive
+
+Activated by default. Permits to source the user shell source file as if you were in a real terminal.
+
+Set it to false if you do not depend on a config file like a `.zshrc` for example. 


### PR DESCRIPTION
Adds interative mode to shell call to source .zshrc or .bashrc config files.
Adds additional ENV vars to fetch by providing their names in configuration.
This permits to fetch important vars for compilation like LIBRARY_PATH or CPLUS_INCLUDE_FOLDER.
This commit modifies also modifies the way to store plugin preferences.
Check the README.
