### PR TITLE
Only re-set path when preference changes

### DIFF
--- a/FixPath.py
+++ b/FixPath.py
@@ -14,6 +14,7 @@ def isMac():
 
 if isMac():
 	fixPathSettings = None
+	lastAdditionalPathItems = None
 	originalEnv = {}
 
 	def getSysPath():
@@ -34,17 +35,24 @@ if isMac():
 
 
 	def fixPath():
-		currSysPath = getSysPath()
-		# Basic sanity check to make sure our new path is not empty
-		if len(currSysPath) < 1:
-			return False
+		additionalPathItems = fixPathSettings.get("additional_path_items", []);
 
-		environ['PATH'] = currSysPath
+		# Only do work if path items changes
+		global lastAdditionalPathItems
+		if additionalPathItems != lastAdditionalPathItems:
+			lastAdditionalPathItems = additionalPathItems
 
-		for pathItem in fixPathSettings.get("additional_path_items", []):
-			environ['PATH'] = pathItem + ':' + environ['PATH']
+			currSysPath = getSysPath()
+			# Basic sanity check to make sure our new path is not empty
+			if len(currSysPath) < 1:
+				return False
 
-		return True
+			environ['PATH'] = currSysPath
+
+			for pathItem in additionalPathItems:
+				environ['PATH'] = pathItem + ':' + environ['PATH']
+
+			return True
 
 
 	def plugin_loaded():


### PR DESCRIPTION
Because preferences change when you do lots of things like change font size, and because working out the path is quite costly, only do it the first time the plugin is loaded, or if the additional_path_items preference changes.

This is a *massive* performance improvement on my machine. Specifically for the setting fonts case, it could mean it took seconds to change font size.